### PR TITLE
Correct layout mistake

### DIFF
--- a/components/comments/Comment.js
+++ b/components/comments/Comment.js
@@ -52,7 +52,7 @@ function Comment({ comment, indexUrl }) {
 			</div>
 			<div className="flex-initial">
 				<UserLine withAvatar={false} user={comment.user} />
-				<div className="p-2 bg-gray-100 break-word shadow-xs rounded-md">
+				<div className="p-2 break-words bg-gray-100 shadow-xs rounded-md">
 					{editing ? (
 						<CommentEdit comment={comment} onSubmit={onEdit} />
 					) : (

--- a/styles/index.css
+++ b/styles/index.css
@@ -391,3 +391,7 @@ th {
 		padding-bottom: 0px !important;
 	}
 }
+
+.break-words {
+	word-break: break-word;
+}


### PR DESCRIPTION
Comments with long strings (such as URLs) would previously break the layout. With the fixed word break, this is now corrected